### PR TITLE
Implement `Display` trait and corresponding test

### DIFF
--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -9,6 +9,7 @@
 //!
 //! [sysexits-man-url]: https://man.openbsd.org/sysexits
 
+use std::fmt;
 use std::process::{ExitCode as StdExitCode, Termination};
 
 /// `ExitCode` is a type that represents the system exit code constants as
@@ -255,7 +256,7 @@ impl ExitCode {
     }
 }
 
-impl std::fmt::Display for ExitCode {
+impl fmt::Display for ExitCode {
     /// Implements the `Display` trait.
     ///
     /// `sysexits::ExitCode` implements the `Display` trait such that it can be
@@ -271,7 +272,7 @@ impl std::fmt::Display for ExitCode {
     /// assert_eq!(&format!("{}", ExitCode::Ok), "0");
     /// assert_eq!(&format!("{}", ExitCode::Usage), "64");
     /// ```
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", *self as u8)
     }
 }

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -255,6 +255,27 @@ impl ExitCode {
     }
 }
 
+impl std::fmt::Display for ExitCode {
+    /// Implements the `Display` trait.
+    ///
+    /// `sysexits::ExitCode` implements the `Display` trait such that it can be
+    /// formatted using the given formatter.  Thereby, the respective variant
+    /// will be casted to its integer representation `u8`, at first, before
+    /// being processed by the given formatter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use sysexits::ExitCode;
+    /// #
+    /// assert_eq!(&format!("{}", ExitCode::Ok), "0");
+    /// assert_eq!(&format!("{}", ExitCode::Usage), "64");
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", *self as u8)
+    }
+}
+
 impl From<ExitCode> for StdExitCode {
     #[inline]
     fn from(code: ExitCode) -> Self {
@@ -272,6 +293,26 @@ impl Termination for ExitCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_display_trait_implementation() {
+        assert_eq!(format!("{}", ExitCode::Ok), format!("{}", 0));
+        assert_eq!(format!("{}", ExitCode::Usage), format!("{}", 64));
+        assert_eq!(format!("{}", ExitCode::DataErr), format!("{}", 65));
+        assert_eq!(format!("{}", ExitCode::NoInput), format!("{}", 66));
+        assert_eq!(format!("{}", ExitCode::NoUser), format!("{}", 67));
+        assert_eq!(format!("{}", ExitCode::NoHost), format!("{}", 68));
+        assert_eq!(format!("{}", ExitCode::Unavailable), format!("{}", 69));
+        assert_eq!(format!("{}", ExitCode::Software), format!("{}", 70));
+        assert_eq!(format!("{}", ExitCode::OsErr), format!("{}", 71));
+        assert_eq!(format!("{}", ExitCode::OsFile), format!("{}", 72));
+        assert_eq!(format!("{}", ExitCode::CantCreat), format!("{}", 73));
+        assert_eq!(format!("{}", ExitCode::IoErr), format!("{}", 74));
+        assert_eq!(format!("{}", ExitCode::TempFail), format!("{}", 75));
+        assert_eq!(format!("{}", ExitCode::Protocol), format!("{}", 76));
+        assert_eq!(format!("{}", ExitCode::NoPerm), format!("{}", 77));
+        assert_eq!(format!("{}", ExitCode::Config), format!("{}", 78));
+    }
 
     #[test]
     fn test_is_success_for_successful_termination() {


### PR DESCRIPTION
Hi, @sorairolake,

First of all, thank you for your crate!  I apply it in some of my Rust binary projects and it helps me a lot to handle occurring errors.

But thereby, I encountered that a certain feature seemed to be missing:  an implementation of the `Display` trait.  This is useful in order to provide additional information for debugging but also for the resulting application itself in case an unhandled error should occur.

Thus, I would like to contribute a working implementation of the `Display` trait to your project.  The change not only brings the implementation itself, but also a dedicated test as well as some initial documentation.

The code is already linted, formatted and checked.  The commit message guidelines were applied.

Please consider to accept this change in order to add a further useful feature to your library.