### PR TITLE
Fix linter warning for `examples/cat.rs`

### DIFF
--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -23,11 +23,7 @@ fn main() -> std::process::ExitCode {
             vec![buf]
         }
     } else {
-        match args
-            .into_iter()
-            .map(|file| std::fs::read_to_string(file))
-            .collect()
-        {
+        match args.into_iter().map(std::fs::read_to_string).collect() {
             Ok(strings) => strings,
             Err(err) => {
                 eprintln!("{err}");


### PR DESCRIPTION
Hi, @sorairolake,

When I explored the code base, I noticed that the linter did not totally agree on the source file `example/cat.rs`.  This change fixes the linter warning properly.