### PR TITLE
[Bugfix] Adjust URLs in `CITATION.cff`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,6 +24,7 @@ authors:
 license:
   - Apache-2.0
   - MIT
+repository-artifact: https://crates.io/crates/sysexits
 repository-code: https://github.com/sorairolake/sysexits-rs
 title: sysexits-rs
-url: https://github.com/sorairolake/sysexits-rs
+url: https://docs.rs/sysexits


### PR DESCRIPTION
This Pull Request adjusts the URLs specified in the `CITATION.cff`.  It now contains information regarding the documentation website (configured to be the main website) as well as the library description on crates.io (configured to be the place with final state artifacts).

By the way, I found a tool which makes adjusting the version information in the configuration files easier.  It is named `bump2version` and is written in Python 3.  For integration, one just needs to define a plain text configuration file to be stored in the repository root.  I tried to set it up for this project but there are still some open points; automatically adjusting the release dates does not seem to be possible, for instance, and the changelog cannot be updated due to the URL being stored as a magic number.  Shall I submit the recent progress in a separate Pull Request anyway, @sorairolake?  The automatism is integrated into the `justfile` and just two files are left for update by hand.