### PR TITLE
[Enhancement] Add Automatic Version Increment

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,21 +2,11 @@
 current_version = 0.3.2
 
 [bumpversion:file:.bumpversion.cfg]
-replace = current_version = {new_version}
-search = current_version = {current_version}
 
 [bumpversion:file:Cargo.toml]
-replace = version = "{new_version}"
-search = version = "{current_version}"
 
 [bumpversion:file:CITATION.cff]
-replace = version: {new_version}
-search = version: {current_version}
 
 [bumpversion:file:README.md]
-replace = sysexits = "{new_version}"
-search = sysexits = "{current_version}"
 
 [bumpversion:file:src/lib.rs]
-replace = #![doc(html_root_url = "https://docs.rs/sysexits/{new_version}/")]
-search = #![doc(html_root_url = "https://docs.rs/sysexits/{current_version}/")]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,22 @@
+[bumpversion]
+current_version = 0.3.2
+
+[bumpversion:file:.bumpversion.cfg]
+replace = current_version = {new_version}
+search = current_version = {current_version}
+
+[bumpversion:file:Cargo.toml]
+replace = version = "{new_version}"
+search = version = "{current_version}"
+
+[bumpversion:file:CITATION.cff]
+replace = version: {new_version}
+search = version: {current_version}
+
+[bumpversion:file:README.md]
+replace = sysexits = "{new_version}"
+search = sysexits = "{current_version}"
+
+[bumpversion:file:src/lib.rs]
+replace = #![doc(html_root_url = "https://docs.rs/sysexits/{new_version}/")]
+search = #![doc(html_root_url = "https://docs.rs/sysexits/{current_version}/")]

--- a/justfile
+++ b/justfile
@@ -42,6 +42,6 @@ default: build
 @fmt-readme:
     npx prettier -w README.md
 
-# Prepare the version increment
-@new-version version part:
-    bump2version --new-version {{version}} {{part}}
+# Increment the version
+@bump part:
+    bump2version {{part}}

--- a/justfile
+++ b/justfile
@@ -41,3 +41,7 @@ default: build
 # Run the formatter for the README
 @fmt-readme:
     npx prettier -w README.md
+
+# Prepare the version increment
+@new-version version part:
+    bump2version --new-version {{version}} {{part}}


### PR DESCRIPTION
This Pull Request adds a new configuration file:  `.bumpversion.cfg`.  This file controls the behaviour of `bump2version`, a Python 3 CLI to automatically update all *version numbers* in the whole repository.  It is self-maintaining, i.e. it will even update itself.

I also added a new recipe to the `justfile`:  `bump {{part}}`.  At the moment, this project is versioned according to the pattern `major.minor.patch`.  Just pass one of those parts to the recipe `bump` and all your *version numbers* will be updated automatically.  (Release dates are not supported by `bump2version`.)

You now just need to call, for instance, `just bump patch` for updating immediately from 0.3.2 to 0.3.3 in all files.  The CFF release date needs to be updated by hand as well as the CHANGELOG which also still needs to be specified manually.  Furthermore, the tool will complain if there are uncommitted changes.  Use `bump2version <part> --allow-dirty` to override this behaviour once.

`bump2version` is free and open source, it is licensed MIT and maintained here:  https://github.com/c4urself/bump2version.