### PR TITLE
[Bugfix] Fix CITATION.cff and bump2version Settings (#3)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,6 @@
 [bumpversion]
 current_version = 0.3.3
 
-[bumpversion:file:.bumpversion.cfg]
-
 [bumpversion:file:Cargo.toml]
 
 [bumpversion:file:CITATION.cff]

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ cff-version: 1.2.0
 message: Please cite this software using these meta data.
 
 # Version information.
-date-released: 2022-09-18
+date-released: 2022-10-24
 version: 0.3.3
 
 # Project information.


### PR DESCRIPTION
Hi, @sorairolake!

I noticed that the release date given in the CITATION.cff did not match the actual release date of v0.3.3, so I fixed this issue.  (Unfortunately, bump2version does not automatically enter the correct release dates on call.)  I saw the outdated release date when I cited this project in a documentation.

Furthermore, I removed `.bumpversion.cfg` from itself.  The file will always update itself.  This was something I did not knew when I originally suggested it in #5, I am sorry about that.