### PR TITLE
Fix conversion from `std::io::ErrorKind`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,8 @@ toc::[]
 
 * Fix conversion from `std::process::ExitStatus` if the process was terminated
   by a signal
+* Fix conversion from `std::io::ErrorKind` to return `ExitCode::NoInput` if
+  error kind is `ErrorKind::NotFound`
 
 == {compare-url}/v0.3.4\...v0.4.0[0.4.0] - 2022-12-29
 

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -351,7 +351,7 @@ impl TryFrom<std::io::ErrorKind> for ExitCode {
         use std::io::ErrorKind;
 
         match kind {
-            ErrorKind::NotFound => Ok(Self::OsFile),
+            ErrorKind::NotFound => Ok(Self::NoInput),
             ErrorKind::PermissionDenied => Ok(Self::NoPerm),
             ErrorKind::ConnectionRefused
             | ErrorKind::ConnectionReset
@@ -554,7 +554,7 @@ mod tests {
 
         assert!(matches!(
             ExitCode::try_from(ErrorKind::NotFound).unwrap(),
-            ExitCode::OsFile
+            ExitCode::NoInput
         ));
         assert!(matches!(
             ExitCode::try_from(ErrorKind::PermissionDenied).unwrap(),


### PR DESCRIPTION
Returns `ExitCode::NoInput` if error kind is `ErrorKind::NotFound`.