### PR TITLE
[Enhancement] Add `ExitCode` Based `Result` Type and Unit Test

### DIFF
--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -11,12 +11,14 @@
 
 use core::fmt;
 #[cfg(feature = "std")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 use std::process::Termination;
 
 /// An `ExitCode` based result type.
 ///
 /// In case of an error, an appropriate variant of `ExitCode` can describe
 /// the exact cause in further detail.
+#[cfg(feature = "std")]
 pub type Result<T> = std::result::Result<T, ExitCode>;
 
 /// `ExitCode` is a type that represents the system exit code constants as
@@ -353,6 +355,8 @@ impl From<ExitCode> for std::process::ExitCode {
     }
 }
 
+#[cfg(feature = "std")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl<T> From<Result<T>> for ExitCode {
     /// Convert an `ExitCode` based result into an `ExitCode`.
     ///
@@ -836,6 +840,7 @@ mod tests {
         assert!(ExitCode::Config.is_failure());
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_result_type() {
         assert_eq!(Into::<ExitCode>::into(Ok::<(), ExitCode>(())), ExitCode::Ok);


### PR DESCRIPTION
Hello, @sorairolake!

This PR adds:

- a `Result` type which returns an `ExitCode` as `Err` variant in order to explain the exact cause in further detail;
- a type conversion function which unpacks an `ExitCode` based result into a pure `ExitCode`; and
- a unit test which demonstrates the new `Result` type and its conversion back to a pure `ExitCode`.

I added some brief information as documentation comments for all new symbols which are exposed by the library.  The test uses the unit type (`()`) and `u8` as example types to demonstrate the new `Result` implementation.

When working on Rust binary crates whose `main` function shall return an `ExitCode`, it is useful to be able to propagate error conditions directly to `main` and to convert the result there into the desired `ExitCode` with minimal effort.  These changes shall help to design the error handling of an application using `ExitCode`s more easily.