### PR TITLE
[Enhancement] Add Linting Workflow for GHA Workflows

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,28 @@
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Copyright (C) 2022-2023 Shun Sakai and Contributors
+#
+
+name: actionlint
+
+on:
+  push:
+    paths:
+      - .github/workflows/*.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: validate
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: actionlint
+        uses: devops-actions/actionlint@v0.1.1

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -7,6 +7,9 @@
 name: actionlint
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/*.yaml
   push:
     paths:
       - .github/workflows/*.yaml

--- a/.github/workflows/cffconvert.yaml
+++ b/.github/workflows/cffconvert.yaml
@@ -7,6 +7,9 @@
 name: cffconvert
 
 on:
+  pull_request:
+    paths:
+      - CITATION.cff
   push:
     paths:
       - CITATION.cff


### PR DESCRIPTION
This PR adds a new GitHub Action workflow which will run a lightweight linter on all GitHub Action workflow files whenever they were edited.  This shall make sure that syntactical issues can be identified rather quickly without having to search for them manually.  The workflow will determine the validity of both the workflow files and the shell scripts they contain in about 5 seconds by pulling a Docker image of the linter "actionlint".