### PR TITLE
Call Docker Images Directly

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -28,4 +28,6 @@ jobs:
           persist-credentials: false
 
       - name: actionlint
-        uses: devops-actions/actionlint@v0.1.1
+        uses: docker://rhysd/actionlint:latest
+        with:
+          args: -color

--- a/.github/workflows/cffconvert.yaml
+++ b/.github/workflows/cffconvert.yaml
@@ -28,6 +28,6 @@ jobs:
           persist-credentials: false
 
       - name: cffconvert
-        uses: citation-file-format/cffconvert-github-action@2.0.0
+        uses: docker://citationcff/cffconvert:latest
         with:
-          args: "--validate"
+          args: --validate


### PR DESCRIPTION
This PR reduces the maintenance effort for and improves the runtime of the GHA workflow and CFF linters by calling their Docker images directly.

At the moment, the linters are called by Actions which are just wrappers around their Docker containers.  As the Docker images are fetched anyway, it saves some time to call them image directly.  Furthermore, by applying the version syntax of Docker, the maintenance effort for the linters can be reduced to zero since Docker allows for the magical version tag `latest`.