### PR TITLE
Extend `io::ErrorKind`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ exclude = [
 [features]
 default = ["std"]
 std = []
+nightly = ["extended_io_error"]
+extended_io_error = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/justfile
+++ b/justfile
@@ -12,6 +12,7 @@ default: build
 # Build a package
 @build:
     cargo build
+    cargo +nightly build --features nightly
 
 # Remove generated artifacts
 @clean:

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -420,8 +420,14 @@ impl From<std::io::ErrorKind> for ExitCode {
             | ErrorKind::BrokenPipe
             | ErrorKind::TimedOut
             | ErrorKind::Interrupted => Self::TempFail,
+            #[cfg(feature = "extended_io_error")]
+            ErrorKind::HostUnreachable | ErrorKind::NetworkUnreachable => Self::NoHost,
             ErrorKind::AddrInUse | ErrorKind::AddrNotAvailable => Self::Unavailable,
+            #[cfg(feature = "extended_io_error")]
+            ErrorKind::NetworkDown => Self::Unavailable,
             ErrorKind::AlreadyExists => Self::CantCreat,
+            #[cfg(feature = "extended_io_error")]
+            ErrorKind::ReadOnlyFilesystem => Self::CantCreat,
             ErrorKind::WouldBlock | ErrorKind::Unsupported => Self::Protocol,
             ErrorKind::InvalidInput | ErrorKind::InvalidData => Self::DataErr,
             ErrorKind::WriteZero | ErrorKind::UnexpectedEof => Self::Software,

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -426,9 +426,9 @@ impl From<std::io::ErrorKind> for ExitCode {
             #[cfg(feature = "extended_io_error")]
             ErrorKind::NetworkDown => Self::Unavailable,
             ErrorKind::AlreadyExists => Self::CantCreat,
+            ErrorKind::WouldBlock | ErrorKind::Unsupported => Self::Protocol,
             #[cfg(feature = "extended_io_error")]
             ErrorKind::ReadOnlyFilesystem => Self::CantCreat,
-            ErrorKind::WouldBlock | ErrorKind::Unsupported => Self::Protocol,
             ErrorKind::InvalidInput | ErrorKind::InvalidData => Self::DataErr,
             ErrorKind::WriteZero | ErrorKind::UnexpectedEof => Self::Software,
             _ => Self::IoErr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@
 //!
 //! [sysexits-man-url]: https://man.openbsd.org/sysexits
 
+#![cfg_attr(feature = "extended_io_error", feature(io_error_more))]
 #![doc(html_root_url = "https://docs.rs/sysexits/0.7.2/")]
 #![no_std]
 #![cfg_attr(doc_cfg, feature(doc_auto_cfg, doc_cfg))]


### PR DESCRIPTION
closes: #51