### PR TITLE
Update `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2022 Kevin Matthes
 # SPDX-FileCopyrightText: 2022 Shun Sakai
-# SPDX-FileCopyrightText: 2023 zSchoen
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
@@ -13,7 +12,6 @@ default: build
 # Build a package
 @build:
     cargo build
-    cargo +nightly build --features nightly
 
 # Remove generated artifacts
 @clean:


### PR DESCRIPTION
This is because `build` recipe will fail if the nightly Rust is not installed.