### PR TITLE
Change to use `bump-my-version`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,0 @@
-[bumpversion]
-current_version = 0.7.7
-
-[bumpversion:file:CITATION.cff]
-
-[bumpversion:file:README.md]
-
-[bumpversion:file:src/lib.rs]

--- a/.bumpversion.cfg.license
+++ b/.bumpversion.cfg.license
@@ -1,4 +1,0 @@
-SPDX-FileCopyrightText: 2022 Kevin Matthes
-SPDX-FileCopyrightText: 2022 Shun Sakai
-
-SPDX-License-Identifier: Apache-2.0 OR MIT

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2022 Kevin Matthes
+# SPDX-FileCopyrightText: 2022 Shun Sakai
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+[tool.bumpversion]
+current_version = "0.7.7"
+
+[[tool.bumpversion.files]]
+filename = "CITATION.cff"
+
+[[tool.bumpversion.files]]
+filename = "README.md"
+
+[[tool.bumpversion.files]]
+filename = "src/lib.rs"

--- a/justfile
+++ b/justfile
@@ -51,5 +51,5 @@ default: build
 
 # Increment the version
 @bump part:
-    bump2version {{part}}
+    bump-my-version bump {{part}}
     cargo set-version --bump {{part}}


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
[`bump2version`](https://github.com/c4urself/bump2version) is no longer maintained.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/sysexits-rs/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/sysexits-rs/blob/develop/CODE_OF_CONDUCT.md
