### PR TITLE
Make `Result` type always available

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,7 @@ project adheres to https://semver.org/[Semantic Versioning].
 === Changed
 
 * Split `exit_code.rs` into submodules ({pull-request-url}/87[#87])
+* Make `Result` type always available ({pull-request-url}/89[#89])
 
 == {compare-url}/v0.7.12\...v0.7.13[0.7.13] - 2024-04-16
 

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -8,7 +8,6 @@
 //! [`<sysexits.h>`]: https://man.openbsd.org/sysexits
 
 mod convert;
-#[cfg(feature = "std")]
 pub mod result;
 
 use core::fmt;

--- a/src/exit_code/result.rs
+++ b/src/exit_code/result.rs
@@ -7,11 +7,11 @@
 
 use super::ExitCode;
 
-/// A [`Result`](std::result::Result) type based on [`ExitCode`].
+/// A [`Result`](core::result::Result) type based on [`ExitCode`].
 ///
 /// In case of an error, an appropriate variant of [`ExitCode`] can describe the
 /// exact cause in further detail.
-pub type Result<T> = std::result::Result<T, ExitCode>;
+pub type Result<T> = core::result::Result<T, ExitCode>;
 
 impl<T> From<Result<T>> for ExitCode {
     /// Converts a [`Result<T>`] into an `ExitCode`.
@@ -49,12 +49,12 @@ mod tests {
     #[test]
     fn result_type() {
         assert_eq!(
-            std::any::type_name::<Result<()>>(),
-            std::any::type_name::<std::result::Result<(), ExitCode>>()
+            core::any::type_name::<Result<()>>(),
+            core::any::type_name::<core::result::Result<(), ExitCode>>()
         );
         assert_eq!(
-            std::any::type_name::<Result<u8>>(),
-            std::any::type_name::<std::result::Result<u8, ExitCode>>()
+            core::any::type_name::<Result<u8>>(),
+            core::any::type_name::<core::result::Result<u8, ExitCode>>()
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,6 @@ extern crate std;
 mod error;
 mod exit_code;
 
-pub use crate::exit_code::ExitCode;
 #[cfg(feature = "std")]
-pub use crate::{error::TryFromExitStatusError, exit_code::result::Result};
+pub use crate::error::TryFromExitStatusError;
+pub use crate::exit_code::{result::Result, ExitCode};


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/sysexits-rs/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/sysexits-rs/blob/develop/CODE_OF_CONDUCT.md
