### PR TITLE
feat!: Remove `extended_io_error` and `nightly` features

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -26,7 +26,6 @@ jobs:
         toolchain-alias:
           - msrv
           - stable
-          - nightly
         include:
           - os-alias: ubuntu
             os: ubuntu-24.04
@@ -41,8 +40,6 @@ jobs:
             toolchain: 1.85.0
           - toolchain-alias: stable
             toolchain: stable
-          - toolchain-alias: nightly
-            toolchain: nightly
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -59,12 +56,6 @@ jobs:
         run: cargo check --target ${{ matrix.target }}
       - name: Check a package (no default features)
         run: cargo check --target ${{ matrix.target }} --no-default-features
-      - name: Check a package (`nightly` feature)
-        if: matrix.toolchain == 'nightly'
-        run: cargo check --target ${{ matrix.target }} -F nightly
-      - name: Check a package (`nightly` feature without `default` feature)
-        if: matrix.toolchain == 'nightly'
-        run: cargo check --target ${{ matrix.target }} --no-default-features -F nightly
 
   test:
     name: Test
@@ -78,7 +69,6 @@ jobs:
         toolchain-alias:
           - msrv
           - stable
-          - nightly
         include:
           - os-alias: ubuntu
             os: ubuntu-24.04
@@ -93,8 +83,6 @@ jobs:
             toolchain: 1.85.0
           - toolchain-alias: stable
             toolchain: stable
-          - toolchain-alias: nightly
-            toolchain: nightly
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -111,12 +99,6 @@ jobs:
         run: cargo test --target ${{ matrix.target }}
       - name: Run tests (no default features)
         run: cargo test --target ${{ matrix.target }} --no-default-features
-      - name: Run tests (`nightly` feature)
-        if: matrix.toolchain == 'nightly'
-        run: cargo test --target ${{ matrix.target }} -F nightly
-      - name: Run tests (`nightly` feature without `default` feature)
-        if: matrix.toolchain == 'nightly'
-        run: cargo test --target ${{ matrix.target }} --no-default-features -F nightly
 
   rustfmt:
     name: Rustfmt

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,13 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/v0.9.1\...HEAD[Unreleased]
+
+=== Removed
+
+* Remove the `extended_io_error` feature and the `nightly` feature
+  ({pull-request-url}/189[#189])
+
 == {compare-url}/v0.9.0\...v0.9.1[0.9.1] - 2025-07-28
 
 === Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,6 @@ test-strategy = "0.4.3"
 
 [features]
 default = ["std"]
-extended_io_error = ["std"]
-nightly = ["extended_io_error"]
 std = []
 
 [lints.clippy]

--- a/README.md
+++ b/README.md
@@ -29,15 +29,6 @@ cargo add sysexits
 
 ### Crate features
 
-#### `extended_io_error`
-
-Enables features that depend on the `io_error_inprogress` and the
-`io_error_more` features. This also enables `std`. This is implied by `nightly`.
-
-#### `nightly`
-
-Enables features that depend on the nightly Rust.
-
 #### `std`
 
 Enables features that depend on the standard library. This is enabled by

--- a/src/exit_code/convert.rs
+++ b/src/exit_code/convert.rs
@@ -705,11 +705,6 @@ mod tests {
             ExitCode::from(Error::from(ErrorKind::ReadOnlyFilesystem)),
             ExitCode::CantCreat
         );
-        #[cfg(feature = "extended_io_error")]
-        assert_eq!(
-            ExitCode::from(Error::from(ErrorKind::FilesystemLoop)),
-            ExitCode::IoErr
-        );
         assert_eq!(
             ExitCode::from(Error::from(ErrorKind::StaleNetworkFileHandle)),
             ExitCode::IoErr
@@ -766,11 +761,6 @@ mod tests {
             ExitCode::from(Error::from(ErrorKind::TooManyLinks)),
             ExitCode::IoErr
         );
-        #[cfg(feature = "extended_io_error")]
-        assert_eq!(
-            ExitCode::from(Error::from(ErrorKind::InvalidFilename)),
-            ExitCode::IoErr
-        );
         assert_eq!(
             ExitCode::from(Error::from(ErrorKind::ArgumentListTooLong)),
             ExitCode::IoErr
@@ -790,11 +780,6 @@ mod tests {
         assert_eq!(
             ExitCode::from(Error::from(ErrorKind::OutOfMemory)),
             ExitCode::OsErr
-        );
-        #[cfg(feature = "extended_io_error")]
-        assert_eq!(
-            ExitCode::from(Error::from(ErrorKind::InProgress)),
-            ExitCode::IoErr
         );
         assert_eq!(
             ExitCode::from(Error::from(ErrorKind::Other)),
@@ -873,11 +858,6 @@ mod tests {
             ExitCode::from(io::ErrorKind::ReadOnlyFilesystem),
             ExitCode::CantCreat
         );
-        #[cfg(feature = "extended_io_error")]
-        assert_eq!(
-            ExitCode::from(io::ErrorKind::FilesystemLoop),
-            ExitCode::IoErr
-        );
         assert_eq!(
             ExitCode::from(io::ErrorKind::StaleNetworkFileHandle),
             ExitCode::IoErr
@@ -910,11 +890,6 @@ mod tests {
             ExitCode::IoErr
         );
         assert_eq!(ExitCode::from(io::ErrorKind::TooManyLinks), ExitCode::IoErr);
-        #[cfg(feature = "extended_io_error")]
-        assert_eq!(
-            ExitCode::from(io::ErrorKind::InvalidFilename),
-            ExitCode::IoErr
-        );
         assert_eq!(
             ExitCode::from(io::ErrorKind::ArgumentListTooLong),
             ExitCode::IoErr
@@ -932,8 +907,6 @@ mod tests {
             ExitCode::Software
         );
         assert_eq!(ExitCode::from(io::ErrorKind::OutOfMemory), ExitCode::OsErr);
-        #[cfg(feature = "extended_io_error")]
-        assert_eq!(ExitCode::from(io::ErrorKind::InProgress), ExitCode::IoErr);
         assert_eq!(ExitCode::from(io::ErrorKind::Other), ExitCode::IoErr);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,10 +38,6 @@
 //!
 //! [`<sysexits.h>`]: https://man.openbsd.org/sysexits
 
-#![cfg_attr(
-    feature = "extended_io_error",
-    feature(io_error_inprogress, io_error_more)
-)]
 #![doc(html_root_url = "https://docs.rs/sysexits/0.9.1/")]
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Since version 0.9.0, specifying these features is meaningless, and most variants of the `io::ErrorKind` are available in Rust 1.85.0, so remove them.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/sysexits-rs/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/sysexits-rs/blob/develop/CODE_OF_CONDUCT.md
